### PR TITLE
Added support for doing card pre authorizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Get the package
 ~~~ go
 package main
 
-import "github.com/Boletia/conekta"
+import "github.com/nubleer/conekta"
 
 func main() {
   client := conekta.NewClient()

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Conekta
 
-Package conekta is a wrapper for the [conekta API](https://www.conekta.io/docs/api)
+Package conekta is a wrapper for the [conekta API](https://www.conekta.io/docs/api) modify by nubleer team.
 
 ## Important!!
 
@@ -12,9 +12,16 @@ First, get your account's private [API key](https://admin.conekta.io/#developers
 
     export CONEKTA_API_KEY=YOUR_PRIVATE_KEY
 
+Or
+
+``` go
+  client := conekta.NewClient()
+  client.ApiKey = "YOUR_PRIVATE_KEY"
+```
+
 Get the package
 
-    go get github.com/Boletia/conekta-go/conekta
+    go get github.com/nubleer/conekta-go/conekta
 
 ## Usage
 
@@ -25,6 +32,7 @@ import "github.com/Boletia/conekta"
 
 func main() {
   client := conekta.NewClient()
+  client.ApiKey = "YOUR_PRIVATE_KEY"
 
   charge := conekta.Charge{
     Description: "Some description",

--- a/conekta/charges.go
+++ b/conekta/charges.go
@@ -12,7 +12,7 @@ type chargesResource struct {
 type Charge struct {
 	Description         string         `json:"description"`
 	Amount              int            `json:"amount"`
-	Capture							*bool					 `json:"capture,omitempty"`	
+	Capture							bool					 `json:"capture,omitempty"`	
 	Currency            string         `json:"currency"`
 	Card                string         `json:"card,omitempty"`
 	MonthlyInstallments int            `json:"monthly_installments,omitempty"`

--- a/conekta/charges.go
+++ b/conekta/charges.go
@@ -12,7 +12,7 @@ type chargesResource struct {
 type Charge struct {
 	Description         string         `json:"description"`
 	Amount              int            `json:"amount"`
-	Capture							bool					 `json:"capture,omitempty"`	
+	Capture							bool					 `json:"capture"`	
 	Currency            string         `json:"currency"`
 	Card                string         `json:"card,omitempty"`
 	MonthlyInstallments int            `json:"monthly_installments,omitempty"`

--- a/conekta/charges.go
+++ b/conekta/charges.go
@@ -12,7 +12,7 @@ type chargesResource struct {
 type Charge struct {
 	Description         string         `json:"description"`
 	Amount              int            `json:"amount"`
-	Capture							bool					 `json:"capture"`	
+	Capture							*bool					 `json:"capture,omitempty"`	
 	Currency            string         `json:"currency"`
 	Card                string         `json:"card,omitempty"`
 	MonthlyInstallments int            `json:"monthly_installments,omitempty"`

--- a/conekta/charges.go
+++ b/conekta/charges.go
@@ -12,6 +12,7 @@ type chargesResource struct {
 type Charge struct {
 	Description         string         `json:"description"`
 	Amount              int            `json:"amount"`
+	Capture							*bool					 `json:"capture,omitempty"`	
 	Currency            string         `json:"currency"`
 	Card                string         `json:"card,omitempty"`
 	MonthlyInstallments int            `json:"monthly_installments,omitempty"`
@@ -30,7 +31,7 @@ type Charge struct {
 	PaymentMethod       *PaymentMethod `json:"payment_method,omitempty"`
 	Details             *Details       `json:"details,omitempty"`
 	Refunds             []Refund       `json:"refunds,omitempty"`
-	Customer            *Customer      `json:"customeromitempty"`
+	Customer            *Customer      `json:"customer,omitempty"`
 }
 
 type Refund struct {

--- a/conekta/conekta.go
+++ b/conekta/conekta.go
@@ -63,6 +63,7 @@ const (
 type Client struct {
 	client    *http.Client
 	userAgent string
+	ApiKey    string
 	BaseURL   *url.URL
 	Charges   *chargesResource
 	Customers *customersResource
@@ -159,12 +160,14 @@ func (c *Client) prepareRequest(method, path string, body interface{}) (*http.Re
 		return string(j)
 	}())
 
-	apiKey := os.Getenv(envConektaAPIKey)
+	if len(c.ApiKey) == 0 {
+		c.ApiKey = os.Getenv(envConektaAPIKey)
+	}
 
-	if len(apiKey) == 0 {
+	if len(c.ApiKey) == 0 {
 		return nil, GonektaError{"Missing CONEKTA_API_KEY"}
 	}
-	req.SetBasicAuth(apiKey, "")
+	req.SetBasicAuth(c.ApiKey, "")
 	return req, nil
 }
 

--- a/conekta/conekta.go
+++ b/conekta/conekta.go
@@ -160,14 +160,15 @@ func (c *Client) prepareRequest(method, path string, body interface{}) (*http.Re
 		return string(j)
 	}())
 
-	if len(c.ApiKey) == 0 {
-		c.ApiKey = os.Getenv(envConektaAPIKey)
-	}
+	apiKey := c.ApiKey
 
-	if len(c.ApiKey) == 0 {
+	if len(apiKey) == 0 {
+		apiKey = os.Getenv(envConektaAPIKey)
+	}
+	if len(apiKey) == 0 {
 		return nil, GonektaError{"Missing CONEKTA_API_KEY"}
 	}
-	req.SetBasicAuth(c.ApiKey, "")
+	req.SetBasicAuth(apiKey, "")
 	return req, nil
 }
 

--- a/example/main.go
+++ b/example/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/Boletia/conekta-go/conekta"
+	"github.com/nubleer/conekta-go/conekta"
 	"log"
 )
 
@@ -9,6 +9,7 @@ var client *conekta.Client
 
 func init() {
 	client = conekta.NewClient()
+	client.ApiKey = "<api_key>"
 }
 
 func main() {
@@ -59,7 +60,7 @@ func createCardCharge() {
 
 func createPlan() {
 	p := &conekta.Plan{
-		Name: "Golden Boy",
+		Name:   "Golden Boy",
 		Amount: 333333,
 	}
 

--- a/test/customer.go
+++ b/test/customer.go
@@ -7,11 +7,12 @@ import (
 )
 
 type Customer struct {
-	Id     string `db:"-" json:"id"`
-	Name   string `db:"-" json:"name"`
-	Email  string `db:"-" json:"email"`
-	Card   *base.CreditCard
-	Charge *base.Charge
+	Id           string `db:"-" json:"id"`
+	Name         string `db:"-" json:"name"`
+	Email        string `db:"-" json:"email"`
+	Card         *base.CreditCard
+	Charge       *base.Charge
+	Subscription *base.Subscription
 	*base.Client
 }
 
@@ -19,10 +20,20 @@ func NewCustomer(customerId string, cardToken string) *Customer {
 	customer := &Customer{}
 	customer.Client = base.NewClient()
 	customer.Card = &base.CreditCard{}
+	customer.Subscription = &base.Subscription{}
 
 	customer.Id = customerId
 	customer.Card.Token = cardToken
 	return customer
+}
+
+func (self *Customer) CreateSubscription() (err error) {
+	result, err := self.Customers.CreateSubscription(self.Id, self.Subscription)
+	if err != nil {
+		return
+	}
+	log.Printf("Resultado: $v", result)
+	return
 }
 
 func (self *Customer) Pause() (err error) {
@@ -35,10 +46,32 @@ func (self *Customer) Pause() (err error) {
 }
 
 func (self *Customer) Resume() (err error) {
+	log.Printf("Activando cuenta: %v", self.Id)
 	subscription, err := self.Customers.ResumeSubscription(self.Id)
 	if err != nil {
 		return
 	}
 	log.Printf("Subscripción activada: $v", subscription)
+	return
+}
+
+func (self *Customer) Cancel() (err error) {
+	log.Printf("Cancelando cuenta: %v", self.Id)
+	subscription, err := self.Customers.CancelSubscription(self.Id)
+	if err != nil {
+		return
+	}
+	log.Printf("Subscripción Cancelada: $v", subscription)
+	return
+}
+
+func (self *Customer) UpdateSubscription(subs *base.Subscription) (err error) {
+	log.Printf("Actualizando suscripción")
+	var subscription *base.Subscription
+	subscription, err = self.Customers.UpdateSubscription(self.Id, subs)
+	if err != nil {
+		return
+	}
+	log.Printf("Subscripción actualizada! : %v", subscription)
 	return
 }

--- a/test/customer.go
+++ b/test/customer.go
@@ -1,0 +1,44 @@
+package test
+
+import (
+	"log"
+
+	base "github.com/nubleer/conekta-go/conekta"
+)
+
+type Customer struct {
+	Id     string `db:"-" json:"id"`
+	Name   string `db:"-" json:"name"`
+	Email  string `db:"-" json:"email"`
+	Card   *base.CreditCard
+	Charge *base.Charge
+	*base.Client
+}
+
+func NewCustomer(customerId string, cardToken string) *Customer {
+	customer := &Customer{}
+	customer.Client = base.NewClient()
+	customer.Card = &base.CreditCard{}
+
+	customer.Id = customerId
+	customer.Card.Token = cardToken
+	return customer
+}
+
+func (self *Customer) Pause() (err error) {
+	subscription, err := self.Customers.PauseSubscription(self.Id)
+	if err != nil {
+		return
+	}
+	log.Printf("Subscripción pausada: $v", subscription)
+	return
+}
+
+func (self *Customer) Resume() (err error) {
+	subscription, err := self.Customers.ResumeSubscription(self.Id)
+	if err != nil {
+		return
+	}
+	log.Printf("Subscripción activada: $v", subscription)
+	return
+}

--- a/test/customer_test.go
+++ b/test/customer_test.go
@@ -1,0 +1,26 @@
+package test
+
+import "testing"
+
+var customer *Customer
+
+func TestSetUp(t *testing.T) {
+	customer = NewCustomer("cus_zZ42sCRYK1br5zajw", "")
+	customer.ApiKey = "<api_key>"
+}
+
+func TestPaused(t *testing.T) {
+	if err := customer.Pause(); err != nil {
+		t.Logf("No se pudo actualizar la subscripción:  %v", err)
+		return
+	}
+	t.Logf("Subscripción actualizada!")
+}
+
+func TestResume(t *testing.T) {
+	if err := customer.Resume(); err != nil {
+		t.Logf("No se pudo actualizar la subscripción:  %v", err)
+		return
+	}
+	t.Logf("Subscripción actualizada!")
+}


### PR DESCRIPTION
Conekta supports charge pre authorizations to validate a card before doing any actual charge. I've added the "Capture" parameter to the Charge struct. If you want to preauthorize a charge, just send a Capture=false value. The transaction will appear in the Conekta https logs with a status of "pre_authorized". The bank will hold the amount of the charge for a max period of 24 hrs and then the amount will be returned to the bank account.

The advantage of doing this, is that Conekta does not take a fee because no actual money transaction is made. 

This method is undocumented in the Conekta API and was provided over the phone by its support team. To use it, you should add an extra parameter in your Charge struct:

``` go
client := conekta.NewClient()
capture := false
charge := conekta.Charge{
    Description: "Some description",
    Amount: 45000,
    Capture: &capture
    Cash: PaymentOxxo{"type":"oxxo"},
  }

 charge, err = client.Charges.Create(charge)
```
