### PR TITLE
fix(charges): add fields to support SPEI response

### DIFF
--- a/conekta/charges.go
+++ b/conekta/charges.go
@@ -12,7 +12,7 @@ type chargesResource struct {
 type Charge struct {
 	Description         string         `json:"description"`
 	Amount              int            `json:"amount"`
-	Capture							*bool					 `json:"capture,omitempty"`	
+	Capture             *bool          `json:"capture,omitempty"`
 	Currency            string         `json:"currency"`
 	Card                string         `json:"card,omitempty"`
 	MonthlyInstallments int            `json:"monthly_installments,omitempty"`
@@ -84,6 +84,8 @@ type PaymentMethod struct {
 	ExpMonth      string     `json:"exp_month,omitempty"`
 	ExpYear       string     `json:"exp_year,omitempty"`
 	Name          string     `json:"name,omitempty"`
+	Clabe         string     `json:"clabe,omitempty"`
+	Bank          string     `json:"bank,omitempty"`
 	Address       *Address   `json:"address,omitempty"`
 }
 


### PR DESCRIPTION
Hi, I add fields (Bank and Bank), to support SPEI transfers with `conekta.BankPayment{"type": "spei"}`
